### PR TITLE
fix: use 'uri' to percent-encode string

### DIFF
--- a/lib/typesense.rb
+++ b/lib/typesense.rb
@@ -3,6 +3,7 @@
 module Typesense
 end
 
+require 'uri'
 require_relative 'typesense/version'
 require_relative 'typesense/configuration'
 require_relative 'typesense/client'

--- a/lib/typesense/alias.rb
+++ b/lib/typesense/alias.rb
@@ -18,7 +18,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Aliases::RESOURCE_PATH}/#{ERB::Util.url_encode(@name)}"
+      "#{Aliases::RESOURCE_PATH}/#{URI.encode_www_form_component(@name)}"
     end
   end
 end

--- a/lib/typesense/aliases.rb
+++ b/lib/typesense/aliases.rb
@@ -24,7 +24,7 @@ module Typesense
     private
 
     def endpoint_path(alias_name)
-      "#{Aliases::RESOURCE_PATH}/#{ERB::Util.url_encode(alias_name)}"
+      "#{Aliases::RESOURCE_PATH}/#{URI.encode_www_form_component(alias_name)}"
     end
   end
 end

--- a/lib/typesense/analytics_rule.rb
+++ b/lib/typesense/analytics_rule.rb
@@ -18,7 +18,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{AnalyticsRules::RESOURCE_PATH}/#{ERB::Util.url_encode(@rule_name)}"
+      "#{AnalyticsRules::RESOURCE_PATH}/#{URI.encode_www_form_component(@rule_name)}"
     end
   end
 end

--- a/lib/typesense/analytics_rules.rb
+++ b/lib/typesense/analytics_rules.rb
@@ -24,7 +24,7 @@ module Typesense
     private
 
     def endpoint_path(operation = nil)
-      "#{AnalyticsRules::RESOURCE_PATH}#{operation.nil? ? '' : "/#{ERB::Util.url_encode(operation)}"}"
+      "#{AnalyticsRules::RESOURCE_PATH}#{operation.nil? ? '' : "/#{URI.encode_www_form_component(operation)}"}"
     end
   end
 end

--- a/lib/typesense/collection.rb
+++ b/lib/typesense/collection.rb
@@ -27,7 +27,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@name)}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@name)}"
     end
   end
 end

--- a/lib/typesense/document.rb
+++ b/lib/typesense/document.rb
@@ -23,7 +23,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Documents::RESOURCE_PATH}/#{ERB::Util.url_encode(@document_id)}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Documents::RESOURCE_PATH}/#{URI.encode_www_form_component(@document_id)}"
     end
   end
 end

--- a/lib/typesense/documents.rb
+++ b/lib/typesense/documents.rb
@@ -75,7 +75,7 @@ module Typesense
     private
 
     def endpoint_path(operation = nil)
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Documents::RESOURCE_PATH}#{operation.nil? ? '' : "/#{operation}"}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Documents::RESOURCE_PATH}#{operation.nil? ? '' : "/#{operation}"}"
     end
   end
 end

--- a/lib/typesense/key.rb
+++ b/lib/typesense/key.rb
@@ -18,7 +18,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Keys::RESOURCE_PATH}/#{ERB::Util.url_encode(@id)}"
+      "#{Keys::RESOURCE_PATH}/#{URI.encode_www_form_component(@id)}"
     end
   end
 end

--- a/lib/typesense/override.rb
+++ b/lib/typesense/override.rb
@@ -19,7 +19,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Overrides::RESOURCE_PATH}/#{ERB::Util.url_encode(@override_id)}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Overrides::RESOURCE_PATH}/#{URI.encode_www_form_component(@override_id)}"
     end
   end
 end

--- a/lib/typesense/overrides.rb
+++ b/lib/typesense/overrides.rb
@@ -25,7 +25,7 @@ module Typesense
     private
 
     def endpoint_path(operation = nil)
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Overrides::RESOURCE_PATH}#{operation.nil? ? '' : "/#{ERB::Util.url_encode(operation)}"}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Overrides::RESOURCE_PATH}#{operation.nil? ? '' : "/#{URI.encode_www_form_component(operation)}"}"
     end
   end
 end

--- a/lib/typesense/preset.rb
+++ b/lib/typesense/preset.rb
@@ -18,7 +18,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Presets::RESOURCE_PATH}/#{ERB::Util.url_encode(@preset_name)}"
+      "#{Presets::RESOURCE_PATH}/#{URI.encode_www_form_component(@preset_name)}"
     end
   end
 end

--- a/lib/typesense/presets.rb
+++ b/lib/typesense/presets.rb
@@ -24,7 +24,7 @@ module Typesense
     private
 
     def endpoint_path(operation = nil)
-      "#{Presets::RESOURCE_PATH}#{operation.nil? ? '' : "/#{ERB::Util.url_encode(operation)}"}"
+      "#{Presets::RESOURCE_PATH}#{operation.nil? ? '' : "/#{URI.encode_www_form_component(operation)}"}"
     end
   end
 end

--- a/lib/typesense/synonym.rb
+++ b/lib/typesense/synonym.rb
@@ -19,7 +19,7 @@ module Typesense
     private
 
     def endpoint_path
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Synonyms::RESOURCE_PATH}/#{ERB::Util.url_encode(@synonym_id)}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Synonyms::RESOURCE_PATH}/#{URI.encode_www_form_component(@synonym_id)}"
     end
   end
 end

--- a/lib/typesense/synonyms.rb
+++ b/lib/typesense/synonyms.rb
@@ -25,7 +25,7 @@ module Typesense
     private
 
     def endpoint_path(operation = nil)
-      "#{Collections::RESOURCE_PATH}/#{ERB::Util.url_encode(@collection_name)}#{Synonyms::RESOURCE_PATH}#{operation.nil? ? '' : "/#{ERB::Util.url_encode(operation)}"}"
+      "#{Collections::RESOURCE_PATH}/#{URI.encode_www_form_component(@collection_name)}#{Synonyms::RESOURCE_PATH}#{operation.nil? ? '' : "/#{URI.encode_www_form_component(operation)}"}"
     end
   end
 end

--- a/spec/typesense/alias_spec.rb
+++ b/spec/typesense/alias_spec.rb
@@ -25,7 +25,7 @@ describe Typesense::Alias do
     end
 
     it 'returns the specified alias with URI encoded name' do
-      stub_request(:get, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/aliases/abc123%3F%3D%2B-_!%40%23%24%25%5E%26*()~%20%2F', typesense.configuration.nodes[0]))
+      stub_request(:get, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/aliases/abc123%3F%3D%2B-_!%40%23%24%25%5E%26*()~+%2F', typesense.configuration.nodes[0]))
         .with(headers: {
                 'X-Typesense-Api-Key' => typesense.configuration.api_key,
                 'Content-Type' => 'application/json'

--- a/typesense-ruby.gemspec
+++ b/typesense-ruby.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'typesense/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'typesense'
+  spec.name          = 'typesense-ruby'
   spec.version       = Typesense::VERSION
   spec.authors       = ['Typesense, Inc.']
   spec.email         = ['contact@typesense.org']


### PR DESCRIPTION
- explicitly require 'uri'. resolve #34
- uri is a lighter library compared to erb

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
