### PR TITLE
Add truncate collection documents

### DIFF
--- a/examples/collections_and_documents.rb
+++ b/examples/collections_and_documents.rb
@@ -145,6 +145,16 @@ ap collection
 #   "num_documents"         => 0
 # }
 
+###
+# Truncate a collection
+#   Deletion returns the number of documents deleted
+collection = @typesense.collections['companies'].truncate
+ap collection
+
+# {
+#   "num_deleted": 125
+# }
+
 # Let's create the collection again for use in our remaining examples
 @typesense.collections.create(schema)
 

--- a/lib/typesense/collection.rb
+++ b/lib/typesense/collection.rb
@@ -9,7 +9,7 @@ module Typesense
       @api_call  = api_call
       @documents = Documents.new(@name, @api_call)
       @overrides = Overrides.new(@name, @api_call)
-      @synonyms = Synonyms.new(@name, @api_call)
+      @synonyms  = Synonyms.new(@name, @api_call)
     end
 
     def retrieve

--- a/lib/typesense/documents.rb
+++ b/lib/typesense/documents.rb
@@ -72,6 +72,10 @@ module Typesense
       @api_call.delete(endpoint_path, query_parameters)
     end
 
+    def truncate
+      @api_call.delete(endpoint_path, { truncate: true })
+    end
+
     private
 
     def endpoint_path(operation = nil)

--- a/spec/typesense/documents_spec.rb
+++ b/spec/typesense/documents_spec.rb
@@ -242,6 +242,24 @@ describe Typesense::Documents do
     end
   end
 
+  describe '#truncate' do
+    it 'truncate documents in a collection' do
+      stub_request(:delete, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/collections/companies/documents', typesense.configuration.nodes[0]))
+        .with(headers: {
+                'X-Typesense-Api-Key' => typesense.configuration.api_key,
+                'Content-Type' => 'application/json'
+              },
+              query: {
+                truncate: true
+              })
+        .to_return(status: 200, body: '{ "num_deleted": 1 }', headers: { 'Content-Type': 'application/json' })
+
+      result = companies_documents.truncate
+
+      expect(result['num_deleted']).to eq(1)
+    end
+  end
+
   describe '#search' do
     let(:search_parameters) do
       {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

The truncate option mentioned in the [Typesense docs](https://typesense.org/docs/28.0/api/collections.html#truncate-a-collection) could be integrated directly into the gem as a shortcut.

Example:
```
###
# Truncate a collection
#   Deletion returns the number of documents deleted
collection = @typesense.collections['companies'].truncate
ap collection

# {
#   "num_deleted": 125
# }
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
