### PR TITLE
[Example] Correct truncate a collection example

### DIFF
--- a/examples/collections_and_documents.rb
+++ b/examples/collections_and_documents.rb
@@ -147,8 +147,8 @@ ap collection
 
 ###
 # Truncate a collection
-#   Deletion returns the number of documents deleted
-collection = @typesense.collections['companies'].truncate
+#   Truncation returns the number of documents deleted
+collection = @typesense.collections['companies'].documents.truncate
 ap collection
 
 # {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

This can be misleading wrong example for truncate. I just corrected my mistake from previous PR.

NOTE: Also truncate not working at the moment until typesense next patch is released;
https://github.com/typesense/typesense/issues/2221
https://github.com/typesense/typesense/pull/2218

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
