### PR TITLE
Switch Oj to JSON gem

### DIFF
--- a/lib/typesense/api_call.rb
+++ b/lib/typesense/api_call.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'oj'
+require 'json'
 
 module Typesense
   class ApiCall
@@ -81,7 +81,7 @@ module Typesense
             req.params = query_parameters unless query_parameters.nil?
             unless body_parameters.nil?
               body = body_parameters
-              body = Oj.dump(body_parameters, mode: :compat) if headers['Content-Type'] == 'application/json'
+              body = JSON.dump(body_parameters) if headers['Content-Type'] == 'application/json'
               req.body = body
             end
           end
@@ -90,7 +90,7 @@ module Typesense
           @logger.debug "Request #{method}:#{uri_for(endpoint, node)} to Node #{node[:index]} was successfully made (at the network layer). response.status was #{response.status}."
 
           parsed_response = if response.headers && (response.headers['content-type'] || '').include?('application/json')
-                              Oj.load(response.body, mode: :compat)
+                              JSON.parse(response.body)
                             else
                               response.body
                             end

--- a/lib/typesense/documents.rb
+++ b/lib/typesense/documents.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'oj'
+require 'json'
 
 module Typesense
   class Documents
@@ -36,7 +36,7 @@ module Typesense
     # @param [Array,String] documents An array of document hashes or a JSONL string of documents.
     def import(documents, options = {})
       documents_in_jsonl_format = if documents.is_a?(Array)
-                                    documents.map { |document| Oj.dump(document, mode: :compat) }.join("\n")
+                                    documents.map { |document| JSON.dump(document) }.join("\n")
                                   else
                                     documents
                                   end
@@ -51,8 +51,8 @@ module Typesense
 
       if documents.is_a?(Array)
         results_in_jsonl_format.split("\n").map do |r|
-          Oj.load(r)
-        rescue Oj::ParseError => e
+          JSON.parse(r)
+        rescue JSON::ParserError => e
           {
             'success' => false,
             'exception' => e.class.name,

--- a/lib/typesense/stemming_dictionaries.rb
+++ b/lib/typesense/stemming_dictionaries.rb
@@ -11,7 +11,7 @@ module Typesense
 
     def upsert(dict_id, words_and_roots_combinations)
       words_and_roots_combinations_in_jsonl = if words_and_roots_combinations.is_a?(Array)
-                                                words_and_roots_combinations.map { |combo| Oj.dump(combo, mode: :compat) }.join("\n")
+                                                words_and_roots_combinations.map { |combo| JSON.dump(combo) }.join("\n")
                                               else
                                                 words_and_roots_combinations
                                               end
@@ -25,7 +25,7 @@ module Typesense
       )
 
       if words_and_roots_combinations.is_a?(Array)
-        result_in_jsonl.split("\n").map { |r| Oj.load(r) }
+        result_in_jsonl.split("\n").map { |r| JSON.parse(r) }
       else
         result_in_jsonl
       end

--- a/typesense.gemspec
+++ b/typesense.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64', '~> 0.2.0'
   spec.add_dependency 'faraday', '~> 2.8'
-  spec.add_dependency 'json', '~> 2.3'
+  spec.add_dependency 'json', '~> 2.9'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/typesense.gemspec
+++ b/typesense.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64', '~> 0.2.0'
   spec.add_dependency 'faraday', '~> 2.8'
-  spec.add_dependency 'oj', '~> 3.16'
+  spec.add_dependency 'json', '~> 2.3'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Change Summary
This removes the Oj gem and replaces it with `json` which is what comes with Ruby. 

Ruby 3.0 ships with json 2.5.1: https://github.com/ruby/ruby/blob/ruby_3_0/ext/json/lib/json/version.rb
Ruby 3.4 ships with json 2.9.1: https://github.com/ruby/ruby/blob/ruby_3_4/ext/json/lib/json/version.rb

Rails relies on `json` as well.

This removes a dependency, plus Oj is known to have some issues. The json gem's performance has been greatly improved recently by byroot. See this series of blog posts: https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
