### PR TITLE
chore: drop unused dev dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Dev dependencies
 gem 'awesome_print', '~> 1.8'
 gem 'bundler', '~> 2.0'
-gem 'codecov', '~> 0.1'
-gem 'erb'
 gem 'guard', '~> 2.16'
 gem 'guard-rubocop', '~> 1.3'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.9'
-gem 'rspec_junit_formatter', '~> 0.4'
-gem 'rspec-legacy_formatters', '~> 1.0' # For codecov formatter
 gem 'rubocop', '1.72.2'
 gem 'rubocop-rspec', '~> 3.6', require: false
 gem 'simplecov', '~> 0.18'


### PR DESCRIPTION
## Summary

Removes four dev dependencies from the `Gemfile` that are not referenced anywhere in the gem code, specs, `Rakefile`, `Guardfile`, `bin/`, `examples/`, or the CI workflow.

| Gem | Reason |
|---|---|
| `codecov` (`~> 0.1`) | Officially deprecated by Codecov in 2021 in favour of the [Codecov uploader binary / GitHub Action](https://docs.codecov.com/docs/codecov-uploader). The current `.github/workflows/tests.yml` uploads the simplecov report as a GitHub artifact and never requires/invokes the codecov gem. |
| `rspec-legacy_formatters` (`~> 1.0`) | The Gemfile comment said it was only there for the codecov formatter; drops together with codecov. |
| `rspec_junit_formatter` (`~> 0.4`) | The CI workflow runs `bundle exec rspec --format documentation` and produces no JUnit XML, so this formatter has no consumer. |
| `erb` | No `require 'erb'` anywhere in the gem. ERB is in the Ruby stdlib for the supported matrix (>= 2.7), so the standalone gem entry was redundant. |

`awesome_print`, `guard`, `guard-rubocop`, and the rest are kept untouched — `awesome_print` is used heavily in `examples/`, and `guard`/`guard-rubocop` are wired up in `Guardfile` for local rubocop-on-save.

## Verification

- `bundle install` — resolves cleanly, 12 Gemfile deps (was 16), 61 gems total (was 68).
- `bundle exec rubocop` — 97 files inspected, no offenses.
- `bundle exec rspec` — 151 examples, 1 failure, 27 pending. The single failure is `collections_spec.rb:156` (`truncate_len` schema mismatch with the running Typesense container) — pre-existing on `master`, unrelated to this change.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
