### PR TITLE
chore: bump rubocop to ~> 1.86 and rubocop-rspec to ~> 3.9

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,5 +47,13 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/Output:
+  Exclude:
+    - spec/spec_helper.rb # Boots Typesense via docker-compose; the puts/print calls report startup progress to the operator, not to assertions.
+
+Naming/PredicateMethod:
+  Exclude:
+    - spec/spec_helper.rb # ensure_typesense_running returns whether the helper started Typesense, but has heavy side effects, so a `?` suffix would be misleading.
+
 Style/HashSyntax:
   Enabled: false # We still want to support older versions of Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.9'
 gem 'rspec_junit_formatter', '~> 0.4'
 gem 'rspec-legacy_formatters', '~> 1.0' # For codecov formatter
-gem 'rubocop', '1.72.2'
-gem 'rubocop-rspec', '~> 3.6', require: false
+gem 'rubocop', '~> 1.86'
+gem 'rubocop-rspec', '~> 3.9', require: false
 gem 'simplecov', '~> 0.18'
 gem 'timecop', '~> 0.9'
 gem 'webmock', '~> 3.8'

--- a/spec/typesense/collection_spec.rb
+++ b/spec/typesense/collection_spec.rb
@@ -52,7 +52,7 @@ describe Typesense::Collection do
     it 'updates the specified collection' do
       update_schema = {
         'fields' => [
-          'name' => 'field', 'drop' => true
+          { 'name' => 'field', 'drop' => true }
         ]
       }
       stub_request(:patch, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/collections/companies', typesense.configuration.nodes[0]))


### PR DESCRIPTION
## Summary

- `rubocop`: `1.72.2` (pinned exact) → `~> 1.86`
- `rubocop-rspec`: `~> 3.6` → `~> 3.9`

Loosens the rubocop constraint to a pessimistic operator so future patch/minor bumps don't require another Gemfile change.

## What broke (and why it didn't)

The newer cop set surfaced 10 offences. They split into three groups:

### 1. `Style/HashAsLastArrayItem` + `Layout/SpaceInsideHashLiteralBraces` in `collection_spec.rb` (1 real, autocorrected)

Pre-existing array-of-hash literal that was missing braces. `bundle exec rubocop -a` fixed it cleanly:

```diff
       update_schema = {
         'fields' => [
-          'name' => 'field', 'drop' => true
+          { 'name' => 'field', 'drop' => true }
         ]
       }
```

### 2. `RSpec/Output` in `spec/spec_helper.rb` × 8 (cop misfiring)

The new cop flags `puts`/`print` in spec files because it expects output assertions to be wrapped in `expect { }.to output(...).to_stdout` blocks. But `spec/spec_helper.rb` here is **integration infrastructure** — `ensure_typesense_running` boots Typesense via docker-compose and reports startup progress to the operator. Those are not assertions. Auto-correct would either delete or break the progress messages.

Resolved by adding a scoped exclusion in `.rubocop.yml`:

```yaml
RSpec/Output:
  Exclude:
    - spec/spec_helper.rb
```

### 3. `Naming/PredicateMethod` in `spec/spec_helper.rb` × 1 (cop misfiring)

`ensure_typesense_running` returns a boolean (whether *this* test run started the Typesense container, used by the `after(:suite)` hook to decide whether to tear it down). But the method has heavy side effects — it pulls a docker image, starts a container, polls a health endpoint, and writes to stdout. Renaming to `ensure_typesense_running?` to satisfy the predicate-naming convention would actively mislead callers about its cost. Same scoped exclusion treatment.

## Verification

- `bundle exec rubocop` — 97 files inspected, **0 offences**.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
