### PR TITLE
fix(test): align local Typesense image with v30+ supported range

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         ruby-version: ['3.0', '3.2', '3.3', '3.4']
     services:
       typesense:
-        image: typesense/typesense:30.0.alpha1
+        image: typesense/typesense:30.2
         ports:
           - 8108:8108
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: typesense/typesense:29.0
+    image: typesense/typesense:30.2
     ports:
       - "127.0.0.1:8108:8108"
     volumes:

--- a/spec/typesense/curation_set_spec.rb
+++ b/spec/typesense/curation_set_spec.rb
@@ -27,7 +27,9 @@ describe Typesense::CurationSet do
           'id' => 'rule-1',
           'rule' => {
             'query' => 'test',
-            'match' => 'exact'
+            'match' => 'exact',
+            'stem' => false,
+            'synonyms' => false
           },
           'includes' => [{ 'id' => '123', 'position' => 1 }],
           'excludes' => [],

--- a/spec/typesense/curation_sets_spec.rb
+++ b/spec/typesense/curation_sets_spec.rb
@@ -27,7 +27,9 @@ describe Typesense::CurationSets do
           'id' => 'rule-1',
           'rule' => {
             'query' => 'test',
-            'match' => 'exact'
+            'match' => 'exact',
+            'stem' => false,
+            'synonyms' => false
           },
           'includes' => [{ 'id' => '123', 'position' => 1 }],
           'excludes' => [],


### PR DESCRIPTION
## Summary

The integration spec at `spec/typesense/collections_spec.rb:156` fails locally with:

```diff
Failure/Error: expect(result['fields']).to eq(expected_fields)
Diff:
@@ -8,7 +8,6 @@
   "stem" => false,
   "stem_dictionary" => "",
   "store" => true,
-  "truncate_len" => 100,
   "type" => "string"},
```

The expected schema includes `truncate_len`, which Typesense added to the field schema response in v30.x. But `docker-compose.yml` is still pinned at `typesense/typesense:29.0`, so the field is missing from what the local server actually returns.

The README's compatibility table already states this gem (>= v5.0.0) supports Typesense >= v30.0:

| Typesense Server | typesense-ruby |
|------------------|----------------|
| `>= v30.0`       | `>= v5.0.0`    |

So local development had drifted off the gem's stated supported range. This PR realigns it by bumping to the latest stable patch (`30.2`).

## Changes

- `docker-compose.yml`: `typesense/typesense:29.0` → `typesense/typesense:30.2`.
- `spec/typesense/curation_set_spec.rb` and `spec/typesense/curation_sets_spec.rb`: 30.2 added two new fields (`stem`, `synonyms`) to the curation rule schema response. The fixtures are updated to mirror what the server now returns.

## Verification

- `bundle exec rspec` — **151 examples, 0 failures, 16 pending** (down from 27 pending: 11 specs that were `skip`ped on Typesense 29 are now exercised against 30.2).
- The fix is purely test-infrastructure: no library code is changed.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).