### PR TITLE
chore: bump rubocop to ~> 1.86 and rubocop-rspec to ~> 3.9

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,5 +47,13 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/Output:
+  Exclude:
+    - spec/spec_helper.rb
+
+Naming/PredicateMethod:
+  Exclude:
+    - spec/spec_helper.rb
+
 Style/HashSyntax:
   Enabled: false # We still want to support older versions of Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.9'
 gem 'rspec_junit_formatter', '~> 0.4'
 gem 'rspec-legacy_formatters', '~> 1.0' # For codecov formatter
-gem 'rubocop', '1.72.2'
-gem 'rubocop-rspec', '~> 3.6', require: false
+gem 'rubocop', '~> 1.86'
+gem 'rubocop-rspec', '~> 3.9', require: false
 gem 'simplecov', '~> 0.18'
 gem 'timecop', '~> 0.9'
 gem 'webmock', '~> 3.8'

--- a/spec/typesense/collection_spec.rb
+++ b/spec/typesense/collection_spec.rb
@@ -52,7 +52,7 @@ describe Typesense::Collection do
     it 'updates the specified collection' do
       update_schema = {
         'fields' => [
-          'name' => 'field', 'drop' => true
+          { 'name' => 'field', 'drop' => true }
         ]
       }
       stub_request(:patch, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/collections/companies', typesense.configuration.nodes[0]))


### PR DESCRIPTION
## Summary

- Bump rubocop from 1.72.2 → ~> 1.86
- Bump rubocop-rspec from ~> 3.6 → ~> 3.9
- Loosen exact version pin to allow future patch/minor updates

## Changes
- Fixed 1 real offence in collection_spec.rb (autocorrected)
- Ignored RSpec/Output and Naming/PredicateMethod in spec/spec_helper.rb (used for test setup, not assertions)

## Verification
- rubocop: 0 offences

## Notes
Happy to refactor spec_helper.rb instead of ignoring cops if preferred.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
