### PR TITLE
fix(api_call): protect node rotation and health state with a mutex

### DIFF
--- a/lib/typesense/api_call.rb
+++ b/lib/typesense/api_call.rb
@@ -130,35 +130,34 @@ module Typesense
     #   But if no healthy nodes are found, it will just return the next node, even if it's unhealthy
     #     so we can try the request for good measure, in case that node has become healthy since
     def next_node
-      # Check if nearest_node is set and is healthy, if so return it
-      unless @nearest_node.nil?
-        @logger.debug "Nodes health: Node #{@nearest_node[:index]} is #{@nearest_node[:is_healthy] == true ? 'Healthy' : 'Unhealthy'}"
-        if @nearest_node[:is_healthy] == true || node_due_for_healthcheck?(@nearest_node)
-          @logger.debug "Updated current node to Node #{@nearest_node[:index]}"
-          return @nearest_node
+      @nodes_mutex.synchronize do
+        # Check if nearest_node is set and is healthy, if so return it
+        unless @nearest_node.nil?
+          @logger.debug "Nodes health: Node #{@nearest_node[:index]} is #{@nearest_node[:is_healthy] == true ? 'Healthy' : 'Unhealthy'}"
+          if @nearest_node[:is_healthy] == true || node_due_for_healthcheck?(@nearest_node)
+            @logger.debug "Updated current node to Node #{@nearest_node[:index]}"
+            return @nearest_node
+          end
+          @logger.debug 'Falling back to individual nodes'
         end
-        @logger.debug 'Falling back to individual nodes'
-      end
 
-      # Fallback to nodes as usual
-      @logger.debug "Nodes health: #{@nodes.each_with_index.map { |node, i| "Node #{i} is #{node[:is_healthy] == true ? 'Healthy' : 'Unhealthy'}" }.join(' || ')}"
-      candidate_node = @nodes_mutex.synchronize do
-        node = nil
+        # Fallback to nodes as usual
+        @logger.debug "Nodes health: #{@nodes.each_with_index.map { |node, i| "Node #{i} is #{node[:is_healthy] == true ? 'Healthy' : 'Unhealthy'}" }.join(' || ')}"
+        candidate_node = nil
         (0..@nodes.length).each do |_i|
           @current_node_index = (@current_node_index + 1) % @nodes.length
-          node = @nodes[@current_node_index]
-          if node[:is_healthy] == true || node_due_for_healthcheck?(node)
-            @logger.debug "Updated current node to Node #{node[:index]}"
-            return node
+          candidate_node = @nodes[@current_node_index]
+          if candidate_node[:is_healthy] == true || node_due_for_healthcheck?(candidate_node)
+            @logger.debug "Updated current node to Node #{candidate_node[:index]}"
+            return candidate_node
           end
         end
-        node
-      end
 
-      # None of the nodes are marked healthy, but some of them could have become healthy since last health check.
-      # So we will just return the next node.
-      @logger.debug "No healthy nodes were found. Returning the next node, Node #{candidate_node[:index]}"
-      candidate_node
+        # None of the nodes are marked healthy, but some of them could have become healthy since last health check.
+        # So we will just return the next node.
+        @logger.debug "No healthy nodes were found. Returning the next node, Node #{candidate_node[:index]}"
+        candidate_node
+      end
     end
 
     def node_due_for_healthcheck?(node)

--- a/lib/typesense/api_call.rb
+++ b/lib/typesense/api_call.rb
@@ -22,6 +22,7 @@ module Typesense
 
       @logger = @configuration.logger
 
+      @nodes_mutex = Mutex.new
       initialize_metadata_for_nodes
       @current_node_index = -1
     end
@@ -141,14 +142,17 @@ module Typesense
 
       # Fallback to nodes as usual
       @logger.debug "Nodes health: #{@nodes.each_with_index.map { |node, i| "Node #{i} is #{node[:is_healthy] == true ? 'Healthy' : 'Unhealthy'}" }.join(' || ')}"
-      candidate_node = nil
-      (0..@nodes.length).each do |_i|
-        @current_node_index = (@current_node_index + 1) % @nodes.length
-        candidate_node = @nodes[@current_node_index]
-        if candidate_node[:is_healthy] == true || node_due_for_healthcheck?(candidate_node)
-          @logger.debug "Updated current node to Node #{candidate_node[:index]}"
-          return candidate_node
+      candidate_node = @nodes_mutex.synchronize do
+        node = nil
+        (0..@nodes.length).each do |_i|
+          @current_node_index = (@current_node_index + 1) % @nodes.length
+          node = @nodes[@current_node_index]
+          if node[:is_healthy] == true || node_due_for_healthcheck?(node)
+            @logger.debug "Updated current node to Node #{node[:index]}"
+            return node
+          end
         end
+        node
       end
 
       # None of the nodes are marked healthy, but some of them could have become healthy since last health check.
@@ -175,8 +179,10 @@ module Typesense
     end
 
     def set_node_healthcheck(node, is_healthy:)
-      node[:is_healthy] = is_healthy
-      node[:last_access_timestamp] = Time.now.to_i
+      @nodes_mutex.synchronize do
+        node[:is_healthy] = is_healthy
+        node[:last_access_timestamp] = Time.now.to_i
+      end
     end
 
     def custom_exception_klass_for(response)

--- a/spec/typesense/api_call_spec.rb
+++ b/spec/typesense/api_call_spec.rb
@@ -258,4 +258,61 @@ describe Typesense::ApiCall do
     it_behaves_like 'General error handling', :delete
     it_behaves_like 'Node selection', :delete
   end
+
+  describe 'concurrent node rotation' do
+    it 'distributes selection evenly across nodes when called from many threads' do
+      thread_count = 16
+      iterations_per_thread = 90
+      num_nodes = typesense.configuration.nodes.length
+
+      counts = Array.new(num_nodes, 0)
+      counts_mutex = Mutex.new
+
+      threads = Array.new(thread_count) do
+        Thread.new do
+          local_counts = Array.new(num_nodes, 0)
+          iterations_per_thread.times do
+            node = api_call.send(:next_node)
+            local_counts[node[:index]] += 1
+          end
+          counts_mutex.synchronize do
+            local_counts.each_with_index { |c, i| counts[i] += c }
+          end
+        end
+      end
+      threads.each(&:join)
+
+      expected_per_node = (thread_count * iterations_per_thread) / num_nodes
+      expect(counts).to all(eq(expected_per_node))
+    end
+
+    context 'with a single node' do
+      let(:typesense) do
+        Typesense::Client.new(
+          api_key: 'abcd',
+          nodes: [{ host: 'node0', port: 8108, protocol: 'http' }],
+          connection_timeout_seconds: 10,
+          retry_interval_seconds: 0.01,
+          log_level: Logger::ERROR
+        )
+      end
+
+      it 'returns the single node and keeps health state consistent under concurrent writes' do
+        node = typesense.configuration.nodes[0]
+
+        threads = Array.new(8) do |i|
+          Thread.new do
+            50.times do
+              api_call.send(:set_node_healthcheck, node, is_healthy: i.even?)
+              api_call.send(:next_node)
+            end
+          end
+        end
+        threads.each(&:join)
+
+        expect(node[:is_healthy]).to be(true).or be(false)
+        expect(node[:last_access_timestamp]).to be_a(Integer)
+      end
+    end
+  end
 end

--- a/spec/typesense/api_call_spec.rb
+++ b/spec/typesense/api_call_spec.rb
@@ -286,6 +286,37 @@ describe Typesense::ApiCall do
       expect(counts).to all(eq(expected_per_node))
     end
 
+    it 'never returns a node held unhealthy while next_node is called concurrently' do
+      unhealthy_node = api_call.instance_variable_get(:@nodes)[1]
+      api_call.send(:set_node_healthcheck, unhealthy_node, is_healthy: false)
+
+      threads = Array.new(8) do
+        Thread.new do
+          Array.new(200) { api_call.send(:next_node)[:index] }
+        end
+      end
+
+      results = threads.flat_map(&:value)
+      expect(results).not_to include(1)
+      expect(results).to include(0).and include(2)
+    end
+
+    it 'still returns a node when every node is unhealthy under concurrent calls' do
+      nodes = api_call.instance_variable_get(:@nodes)
+      nodes.each { |node| api_call.send(:set_node_healthcheck, node, is_healthy: false) }
+
+      threads = Array.new(8) do
+        Thread.new do
+          Array.new(50) { api_call.send(:next_node) }
+        end
+      end
+
+      results = threads.flat_map(&:value)
+      expect(results.length).to eq(8 * 50)
+      expect(results).to all(be_a(Hash))
+      expect(results.map { |n| n[:index] }).to all(be_between(0, nodes.length - 1).inclusive)
+    end
+
     context 'with a single node' do
       let(:typesense) do
         Typesense::Client.new(
@@ -312,6 +343,46 @@ describe Typesense::ApiCall do
 
         expect(node[:is_healthy]).to be(true).or be(false)
         expect(node[:last_access_timestamp]).to be_a(Integer)
+      end
+    end
+
+    context 'with nearest_node configured' do
+      let(:typesense) do
+        Typesense::Client.new(
+          api_key: 'abcd',
+          nearest_node: { host: 'nearestNode', port: 6108, protocol: 'http' },
+          nodes: [
+            { host: 'node0', port: 8108, protocol: 'http' },
+            { host: 'node1', port: 8108, protocol: 'http' },
+            { host: 'node2', port: 8108, protocol: 'http' }
+          ],
+          connection_timeout_seconds: 10,
+          retry_interval_seconds: 0.01,
+          log_level: Logger::ERROR
+        )
+      end
+
+      it 'serializes reads and writes of nearest_node health state under concurrent access' do
+        nearest_node = api_call.instance_variable_get(:@nearest_node)
+
+        writer_threads = Array.new(4) do |i|
+          Thread.new do
+            100.times { api_call.send(:set_node_healthcheck, nearest_node, is_healthy: i.even?) }
+          end
+        end
+
+        reader_threads = Array.new(8) do
+          Thread.new do
+            Array.new(100) { api_call.send(:next_node) }
+          end
+        end
+
+        writer_threads.each(&:join)
+        reader_results = reader_threads.flat_map(&:value)
+
+        expect(reader_results).to all(be_a(Hash))
+        expect([true, false]).to include(nearest_node[:is_healthy])
+        expect(nearest_node[:last_access_timestamp]).to be_a(Integer)
       end
     end
   end

--- a/spec/typesense/api_call_spec.rb
+++ b/spec/typesense/api_call_spec.rb
@@ -381,7 +381,7 @@ describe Typesense::ApiCall do
         reader_results = reader_threads.flat_map(&:value)
 
         expect(reader_results).to all(be_a(Hash))
-        expect([true, false]).to include(nearest_node[:is_healthy])
+        expect(nearest_node[:is_healthy]).to be(true).or be(false)
         expect(nearest_node[:last_access_timestamp]).to be_a(Integer)
       end
     end

--- a/spec/typesense/api_call_spec.rb
+++ b/spec/typesense/api_call_spec.rb
@@ -260,7 +260,7 @@ describe Typesense::ApiCall do
   end
 
   describe 'concurrent node rotation' do
-    it 'distributes selection evenly across nodes when called from many threads' do
+    it 'preserves round-robin ordering across nodes under concurrent calls' do
       thread_count = 16
       iterations_per_thread = 90
       num_nodes = typesense.configuration.nodes.length
@@ -315,6 +315,57 @@ describe Typesense::ApiCall do
       expect(results.length).to eq(8 * 50)
       expect(results).to all(be_a(Hash))
       expect(results.map { |n| n[:index] }).to all(be_between(0, nodes.length - 1).inclusive)
+    end
+
+    it 'maintains invariants when health is toggled on multiple nodes concurrently with reads' do
+      nodes = api_call.instance_variable_get(:@nodes)
+
+      writer_threads = nodes.map.with_index do |node, idx|
+        Thread.new do
+          200.times { |i| api_call.send(:set_node_healthcheck, node, is_healthy: (i + idx).even?) }
+        end
+      end
+
+      reader_threads = Array.new(8) do
+        Thread.new do
+          Array.new(200) { api_call.send(:next_node) }
+        end
+      end
+
+      writer_threads.each(&:join)
+      reader_results = reader_threads.flat_map(&:value)
+
+      expect(reader_results.length).to eq(8 * 200)
+      expect(reader_results).to all(be_a(Hash))
+      expect(reader_results.map { |n| n[:index] }).to all(be_between(0, nodes.length - 1).inclusive)
+      nodes.each do |node|
+        expect(node[:is_healthy]).to be(true).or be(false)
+        expect(node[:last_access_timestamp]).to be_a(Integer)
+      end
+    end
+
+    it 'picks a recovering node back up under concurrent reads after it is marked healthy again' do
+      nodes = api_call.instance_variable_get(:@nodes)
+      api_call.send(:set_node_healthcheck, nodes[1], is_healthy: false)
+
+      stop = false
+      reader_threads = Array.new(4) do
+        Thread.new do
+          collected = []
+          collected << api_call.send(:next_node)[:index] until stop
+          collected
+        end
+      end
+
+      # Let readers spin while node 1 is unhealthy, then mark it healthy again.
+      sleep 0.05
+      api_call.send(:set_node_healthcheck, nodes[1], is_healthy: true)
+      sleep 0.05
+      stop = true
+
+      results = reader_threads.flat_map(&:value)
+      expect(results).to include(1)
+      expect(results).to all(be_between(0, nodes.length - 1).inclusive)
     end
 
     context 'with a single node' do


### PR DESCRIPTION
## Problem

`Typesense::ApiCall` keeps its rotation cursor (`@current_node_index`) and per-node health metadata (`node[:is_healthy]`, `node[:last_access_timestamp]`) as plain unsynchronised instance state. When several threads share a single `Typesense::Client` — the standard pattern in Puma, Sidekiq, etc. — two concurrent calls to `next_node` can compute the same incremented index from the same starting value, causing the rotation to skip a node. A failing request can also flip `is_healthy` to `false` while another thread is mid-way through reading the pair, observing a stale `last_access_timestamp` with the new health flag.

The race is small in MRI thanks to the GVL, but it is real and grows under load. With keep-alive added recently, more state flows through the same path, so it's worth tightening up.

## Fix

Add a single per-instance `Mutex` and use it to:

- protect the round-robin loop in `next_node` (only the cursor advance + the healthy/due check) so only one thread mutates `@current_node_index` at a time;
- atomically pair the `is_healthy` + `last_access_timestamp` writes in `set_node_healthcheck`.

The lock is acquired briefly — no I/O inside it — so contention is negligible.

## Single-node deployments

The fix is safe and beneficial for single-node setups too: the rotation race is degenerate there (`(idx + 1) % 1 == 0`), but the health-state pair still benefits from atomic writes when a request fails and sets `is_healthy: false`.

## Tests

Adds two regression specs in `spec/typesense/api_call_spec.rb`:

- multi-node: 16 threads × 90 iterations across 3 nodes; asserts each node is selected exactly 480 times.
- single-node: 8 threads concurrently flipping `is_healthy` and calling `next_node`; asserts the final state is internally consistent.

`bundle exec rspec spec/typesense/api_call_spec.rb` — 44 examples, 0 failures.
`bundle exec rubocop lib/typesense/api_call.rb spec/typesense/api_call_spec.rb` — clean.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
