### PR TITLE
chore: loosen base64 dependency to allow 0.3.x

### DIFF
--- a/typesense.gemspec
+++ b/typesense.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'base64', '~> 0.2.0'
+  spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'faraday', '~> 2.8'
   spec.add_dependency 'json', '~> 2.9'
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Closes #50.

`base64 0.3.0` shipped in May 2025 and `~> 0.2.0` in [`typesense.gemspec`](https://github.com/typesense/typesense-ruby/blob/master/typesense.gemspec#L29) blocks bundler from resolving it.

The only `Base64` API this gem uses is `Base64.encode64` ([`lib/typesense/keys.rb:26,29`](https://github.com/typesense/typesense-ruby/blob/master/lib/typesense/keys.rb)) — that has been stable across every `base64` release.

Loosens the constraint to `~> 0.2`, which allows 0.2.x and 0.3.x while still capping below 1.0 if the API ever changes meaningfully.

## Verification

- `bundle update base64` resolves to `base64 0.3.0`.
- `bundle exec rspec` (api_call, configuration, key, keys specs) — all green against 0.3.0.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
