### PR TITLE
chore: drop Ruby 2.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins: rubocop-rspec
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Style/Documentation:
   Enabled: false

--- a/spec/typesense/collections_spec.rb
+++ b/spec/typesense/collections_spec.rb
@@ -36,7 +36,7 @@ describe Typesense::Collections do
   describe '#create' do
     it 'creates a collection and returns it' do
       # since num_documents is a read-only attribute
-      schema_for_creation = company_schema.reject { |key, _| key == 'num_documents' }
+      schema_for_creation = company_schema.except('num_documents')
 
       stub_request(:post, Typesense::ApiCall.new(typesense.configuration).send(:uri_for, '/collections', typesense.configuration.nodes[0]))
         .with(body: schema_for_creation,

--- a/typesense.gemspec
+++ b/typesense.gemspec
@@ -15,9 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://typesense.org'
   spec.license       = 'Apache-2.0'
 
-  # rubocop:disable Gemspec/RequiredRubyVersion, Lint/RedundantCopDisableDirective
-  spec.required_ruby_version = '>= 2.7'
-  # rubocop:enable Gemspec/RequiredRubyVersion, Lint/RedundantCopDisableDirective
+  spec.required_ruby_version = '>= 3.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Ruby 2.7 has been [EOL since March 2023](https://www.ruby-lang.org/en/downloads/branches/), and the CI matrix in `.github/workflows/tests.yml` only covers 3.0, 3.2, 3.3, 3.4 — 2.7 hasn't been tested for some time. This PR makes the gemspec and rubocop config match what CI actually exercises.

## Changes

- **`typesense.gemspec`**: bump `required_ruby_version` from `>= 2.7` to `>= 3.0`. The `# rubocop:disable Gemspec/RequiredRubyVersion, Lint/RedundantCopDisableDirective` workaround is no longer needed once the floor matches the rubocop target, so it's removed.
- **`.rubocop.yml`**: bump `TargetRubyVersion` from `2.7` to `3.0`.
- **`spec/typesense/collections_spec.rb`**: rubocop autocorrect from the newly-enabled `Style/HashExcept` cop (`Hash#except` was added in 3.0). One line changes from `reject { |key, _| key == 'num_documents' }` to `.except('num_documents')`.

## Compatibility note

This is a breaking change for anyone still installing the gem on Ruby 2.7. They will see a `Gem::RuntimeRequirementNotMetError` from bundler. The workaround for those users is pinning to the previous gem version. Worth tagging this in the next release notes / a major version bump if prefer.

## Verification

- `bundle exec rubocop` — 97 files inspected, no offenses detected.
- `bundle exec rspec spec/typesense/collections_spec.rb:38` (the touched example) — passes.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
