### PR TITLE
docs: add yardoc for client resources and resource class methods

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Nix development environment for the Typesense Ruby client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        ruby = pkgs.ruby_3_4;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            ruby
+            bundler
+            git
+            curl
+            pkg-config
+            openssl
+            libyaml
+            zlib
+            libffi
+            docker
+            docker-compose
+          ];
+
+          shellHook = ''
+            export BUNDLE_PATH="$PWD/.bundle"
+            export BUNDLE_BIN="$PWD/.bundle/bin"
+            export BUNDLE_APP_CONFIG="$PWD/.bundle/config"
+            export GEM_HOME="$PWD/.bundle/ruby"
+            export PATH="$BUNDLE_BIN:$GEM_HOME/bin:$PATH"
+
+            cat <<'EOF'
+            Typesense Ruby dev shell
+
+            First-time setup:
+              bundle install
+
+            Common commands:
+              bundle exec rubocop
+              bundle exec rspec --format documentation
+
+            Integration tests expect Docker to be running.
+            EOF
+          '';
+        };
+      });
+}

--- a/lib/typesense/alias.rb
+++ b/lib/typesense/alias.rb
@@ -7,10 +7,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Find out which collection an alias points to by fetching it
+    #
+    # @example
+    #   client.aliases['my-alias'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html#retrieve-an-alias
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete an alias
+    #
+    # @example
+    #   client.aliases['my-alias'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html#delete-an-alias
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/aliases.rb
+++ b/lib/typesense/aliases.rb
@@ -9,14 +9,34 @@ module Typesense
       @aliases = {}
     end
 
+    # Create or update a collection alias.
+    #
+    # @example
+    #   client.aliases.upsert('my-alias', 'collection_name' => 'products')
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html#create-or-update-an-alias
     def upsert(alias_name, mapping)
       @api_call.put(endpoint_path(alias_name), mapping)
     end
 
+    # List all aliases and the corresponding collections that they map to.
+    #
+    # @example
+    #   client.aliases.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html#list-all-aliases
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end
 
+    # Access an individual collection alias by name.
+    #
+    # @example
+    #   client.aliases['my-alias'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html
+    #
+    # @return [Alias]
     def [](alias_name)
       @aliases[alias_name] ||= Alias.new(alias_name, @api_call)
     end

--- a/lib/typesense/analytics.rb
+++ b/lib/typesense/analytics.rb
@@ -8,10 +8,29 @@ module Typesense
       @api_call = api_call
     end
 
+    # Access the analytics rules resource. Use it to list or create rules, or as an array
+    # to access a single rule by ID.
+    #
+    # @example
+    #   client.analytics.rules.retrieve
+    # @example
+    #   client.analytics.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsRules]
     def rules
       @rules ||= AnalyticsRules.new(@api_call)
     end
 
+    # Access the analytics events resource to send analytics events.
+    #
+    # @example
+    #   client.analytics.events.create('type' => 'click', 'name' => 'products_click', 'data' => {})
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsEvents]
     def events
       @events ||= AnalyticsEvents.new(@api_call)
     end

--- a/lib/typesense/analytics_events.rb
+++ b/lib/typesense/analytics_events.rb
@@ -8,10 +8,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Submit a single analytics event. The event must correspond to an existing analytics rule by name.
+    #
+    # @example
+    #   client.analytics.events.create('type' => 'click', 'name' => 'products_click', 'data' => {})
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def create(params)
       @api_call.post(self.class::RESOURCE_PATH, params)
     end
 
+    # Retrieve the most recent events for a user and rule.
+    #
+    # @example
+    #   client.analytics.events.retrieve('user_id' => 'u1', 'name' => 'products_click', 'n' => 10)
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def retrieve(params = {})
       @api_call.get(self.class::RESOURCE_PATH, params)
     end

--- a/lib/typesense/analytics_events_v1.rb
+++ b/lib/typesense/analytics_events_v1.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Submit a single legacy v1 analytics event. The event must correspond to an existing analytics rule by name.
+    #
+    # @example
+    #   client.analytics_v1.events.create('type' => 'click', 'name' => 'products_click', 'data' => {})
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
     def create(params)
       @api_call.post(endpoint_path, params)
     end

--- a/lib/typesense/analytics_rule.rb
+++ b/lib/typesense/analytics_rule.rb
@@ -7,14 +7,32 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve the details of an analytics rule, given it's name
+    #
+    # @example
+    #   client.analytics.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Permanently deletes an analytics rule, given it's name
+    #
+    # @example
+    #   client.analytics.rules['rule-1'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def delete
       @api_call.delete(endpoint_path)
     end
 
+    # Upserts an analytics rule with the given name.
+    #
+    # @example
+    #   client.analytics.rules['products_query_hits'].update('type' => 'popular_queries', 'params' => {})
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def update(params)
       @api_call.put(endpoint_path, params)
     end

--- a/lib/typesense/analytics_rule_v1.rb
+++ b/lib/typesense/analytics_rule_v1.rb
@@ -7,10 +7,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve a legacy v1 analytics rule by name.
+    #
+    # @example
+    #   client.analytics_v1.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete a legacy v1 analytics rule by name.
+    #
+    # @example
+    #   client.analytics_v1.rules['rule-1'].delete
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/analytics_rules.rb
+++ b/lib/typesense/analytics_rules.rb
@@ -8,14 +8,34 @@ module Typesense
       @api_call = api_call
     end
 
+    # Create one or more analytics rules. You can send a single rule object or an array of rule objects.
+    #
+    # @example
+    #   client.analytics.rules.create('name' => 'products_query_hits', 'type' => 'popular_queries', 'params' => {})
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def create(rules)
       @api_call.post(self.class::RESOURCE_PATH, rules)
     end
 
+    # Retrieve all analytics rules.
+    #
+    # @example
+    #   client.analytics.rules.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
     def retrieve
       @api_call.get(self.class::RESOURCE_PATH)
     end
 
+    # Access an individual analytics rule by name.
+    #
+    # @example
+    #   client.analytics.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsRule]
     def [](rule_name)
       AnalyticsRule.new(rule_name, @api_call)
     end

--- a/lib/typesense/analytics_rules_v1.rb
+++ b/lib/typesense/analytics_rules_v1.rb
@@ -9,14 +9,34 @@ module Typesense
       @analytics_rules = {}
     end
 
+    # Upsert a legacy v1 analytics rule by name.
+    #
+    # @example
+    #   client.analytics_v1.rules.upsert('products_query_hits', 'type' => 'popular_queries', 'params' => {})
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
     def upsert(rule_name, params)
       @api_call.put(endpoint_path(rule_name), params)
     end
 
+    # Retrieve all legacy v1 analytics rules.
+    #
+    # @example
+    #   client.analytics_v1.rules.retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual legacy v1 analytics rule by name.
+    #
+    # @example
+    #   client.analytics_v1.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsRuleV1]
     def [](rule_name)
       @analytics_rules[rule_name] ||= AnalyticsRuleV1.new(rule_name, @api_call)
     end

--- a/lib/typesense/analytics_v1.rb
+++ b/lib/typesense/analytics_v1.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Typesense
+  # @deprecated Deprecated starting with Typesense Server v30. Please migrate to `client.analytics` (new Analytics APIs).
   class AnalyticsV1
     RESOURCE_PATH = '/analytics'
 
@@ -8,10 +9,29 @@ module Typesense
       @api_call = api_call
     end
 
+    # Access the legacy v1 analytics rules resource. Use it to list or upsert rules, or as an array
+    # to access a single rule by ID.
+    #
+    # @example
+    #   client.analytics_v1.rules.retrieve
+    # @example
+    #   client.analytics_v1.rules['rule-1'].retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsRulesV1]
     def rules
       @rules ||= AnalyticsRulesV1.new(@api_call)
     end
 
+    # Access the legacy v1 analytics events resource to send analytics events.
+    #
+    # @example
+    #   client.analytics_v1.events.create('type' => 'click', 'name' => 'products_click', 'data' => {})
+    #
+    # @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsEventsV1]
     def events
       @events ||= AnalyticsEventsV1.new(@api_call)
     end

--- a/lib/typesense/client.rb
+++ b/lib/typesense/client.rb
@@ -1,9 +1,186 @@
 # frozen_string_literal: true
 
 module Typesense
+  # Typesense client for indexing, searching, and managing collections.
+  #
+  # @see https://typesense.org/docs/latest/api/
   class Client
-    attr_reader :configuration, :collections, :aliases, :keys, :debug, :health, :metrics, :stats, :operations,
-                :multi_search, :analytics, :analytics_v1, :presets, :stemming, :nl_search_models, :synonym_sets, :curation_sets
+    # @return [Configuration]
+    attr_reader :configuration
+
+    # Access the collections resource. Use it to list or create collections, or as an array to access a single collection by name.
+    #
+    # @example
+    #   client.collections.create('name' => 'products', 'fields' => [{ 'name' => 'title', 'type' => 'string' }])
+    # @example
+    #   client.collections['products'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html
+    #
+    # @return [Collections]
+    attr_reader :collections
+
+    # Access the aliases resource. Use it to upsert or list aliases, or as an array to access a single alias by name.
+    #
+    # @example
+    #   client.aliases.upsert('my-alias', 'collection_name' => 'products')
+    # @example
+    #   client.aliases['my-alias'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collection-alias.html
+    #
+    # @return [Aliases]
+    attr_reader :aliases
+
+    # Access the API keys resource. Use it to create or list keys, or as an array to access a single key by ID.
+    #
+    # @example
+    #   client.keys.create('description' => 'Search-only key', 'actions' => ['documents:search'], 'collections' => ['*'])
+    # @example
+    #   client.keys[1].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html
+    #
+    # @return [Keys]
+    attr_reader :keys
+
+    # Retrieve server version and state information.
+    #
+    # @example
+    #   client.debug.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html#debug
+    #
+    # @return [Debug]
+    attr_reader :debug
+
+    # Checks if Typesense server is ready to accept requests.
+    #
+    # @example
+    #   client.health.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html#health
+    #
+    # @return [Health]
+    attr_reader :health
+
+    # Get current RAM, CPU, Disk & Network usage metrics.
+    #
+    # @example
+    #   client.metrics.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
+    #
+    # @return [Metrics]
+    attr_reader :metrics
+
+    # Get stats about API endpoints.
+    #
+    # @example
+    #   client.stats.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
+    #
+    # @return [Stats]
+    attr_reader :stats
+
+    # Cluster operations: snapshots, voting, cache, on-disk compaction, slow request log.
+    #
+    # @example
+    #   client.operations.perform('snapshot', 'snapshot_path' => '/tmp/snap')
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
+    #
+    # @return [Operations]
+    attr_reader :operations
+
+    # Send multiple search requests in a single HTTP request.
+    #
+    # @example
+    #   client.multi_search.perform('searches' => [{ 'collection' => 'products', 'q' => '*' }])
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#federated-multi-search
+    #
+    # @return [MultiSearch]
+    attr_reader :multi_search
+
+    # Manage analytics rules and events.
+    #
+    # @example
+    #   client.analytics.rules.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+    #
+    # @return [Analytics]
+    attr_reader :analytics
+
+    # Legacy v1 analytics API for rules and events.
+    #
+    # @example
+    #   client.analytics_v1.rules.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+    #
+    # @return [AnalyticsV1]
+    attr_reader :analytics_v1
+
+    # Access the presets resource. Use it to upsert or list presets, or as an array to access a single preset by name.
+    #
+    # @example
+    #   client.presets.upsert('listing_view', 'value' => { 'q' => '*' })
+    # @example
+    #   client.presets['listing_view'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
+    #
+    # @return [Presets]
+    attr_reader :presets
+
+    # Manage stemming dictionaries.
+    #
+    # @example
+    #   client.stemming.dictionaries.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
+    #
+    # @return [Stemming]
+    attr_reader :stemming
+
+    # Access the NL search models resource. Use it to create or list models, or as an array to access a single model by ID.
+    #
+    # @example
+    #   client.nl_search_models.create('model_name' => 'openai/gpt-4')
+    # @example
+    #   client.nl_search_models['model-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
+    #
+    # @return [NlSearchModels]
+    attr_reader :nl_search_models
+
+    # Access the synonym sets resource. Use it to upsert or list sets, or as an array to access a single set by name.
+    #
+    # @example
+    #   client.synonym_sets.retrieve
+    # @example
+    #   client.synonym_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
+    #
+    # @return [SynonymSets]
+    attr_reader :synonym_sets
+
+    # Access the curation sets resource. Use it to upsert or list sets, or as an array to access a single set by name.
+    #
+    # @example
+    #   client.curation_sets.retrieve
+    # @example
+    #   client.curation_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [CurationSets]
+    attr_reader :curation_sets
 
     def initialize(options = {})
       @configuration = Configuration.new(options)

--- a/lib/typesense/collection.rb
+++ b/lib/typesense/collection.rb
@@ -2,7 +2,44 @@
 
 module Typesense
   class Collection
-    attr_reader :documents, :overrides, :synonyms
+    # Access the documents resource for this collection. Use it to list, index, search, import, or export documents,
+    # or as an array to access a single document by ID.
+    #
+    # @example
+    #   client.collections['products'].documents.create('id' => '1', 'title' => 'Hat')
+    # @example
+    #   client.collections['products'].documents['1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html
+    #
+    # @return [Documents]
+    attr_reader :documents
+
+    # Access the legacy overrides (curation) resource for this collection. Use it to list or upsert overrides,
+    # or as an array to access a single override by ID.
+    #
+    # @example
+    #   client.collections['products'].overrides.upsert('promote-hat', 'rule' => { 'query' => 'hat', 'match' => 'exact' }, 'includes' => [])
+    # @example
+    #   client.collections['products'].overrides['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [Overrides]
+    attr_reader :overrides
+
+    # Access the legacy synonyms resource for this collection. Use it to list or upsert synonyms,
+    # or as an array to access a single synonym by ID.
+    #
+    # @example
+    #   client.collections['products'].synonyms.upsert('syn-1', 'synonyms' => ['nyc', 'new york'])
+    # @example
+    #   client.collections['products'].synonyms['syn-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
+    #
+    # @return [Synonyms]
+    attr_reader :synonyms
 
     def initialize(name, api_call)
       @name      = name
@@ -12,14 +49,32 @@ module Typesense
       @synonyms  = Synonyms.new(@name, @api_call)
     end
 
+    # Retrieve the details of a collection, given its name.
+    #
+    # @example
+    #   client.collections['products'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html#retrieve-a-collection
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Update a collection's schema to modify the fields and their types.
+    #
+    # @example
+    #   client.collections['products'].update('fields' => [{ 'name' => 'tags', 'type' => 'string[]' }])
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html#update-or-alter-a-collection
     def update(update_schema)
       @api_call.patch(endpoint_path, update_schema)
     end
 
+    # Permanently drops a collection. This action cannot be undone. For large collections, this might have an impact on read latencies.
+    #
+    # @example
+    #   client.collections['products'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html#drop-a-collection
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/collections.rb
+++ b/lib/typesense/collections.rb
@@ -9,14 +9,34 @@ module Typesense
       @collections = {}
     end
 
+    # When a collection is created, we give it a name and describe the fields that will be indexed from the documents added to the collection.
+    #
+    # @example
+    #   client.collections.create('name' => 'products', 'fields' => [{ 'name' => 'title', 'type' => 'string' }])
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html#create-a-collection
     def create(schema)
       @api_call.post(RESOURCE_PATH, schema)
     end
 
+    # Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
+    #
+    # @example
+    #   client.collections.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html#list-all-collections
     def retrieve(options = {})
       @api_call.get(RESOURCE_PATH, options)
     end
 
+    # Access an individual collection by name.
+    #
+    # @example
+    #   client.collections['products'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/collections.html
+    #
+    # @return [Collection]
     def [](collection_name)
       @collections[collection_name] ||= Collection.new(collection_name, @api_call)
     end

--- a/lib/typesense/curation_set.rb
+++ b/lib/typesense/curation_set.rb
@@ -2,6 +2,17 @@
 
 module Typesense
   class CurationSet
+    # Access the items in this curation set. Use it to list items, or as an array
+    # to access a single item by ID.
+    #
+    # @example
+    #   client.curation_sets['my-set'].items.retrieve
+    # @example
+    #   client.curation_sets['my-set'].items['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [CurationSetItems]
     attr_reader :items
 
     def initialize(curation_set_name, api_call)
@@ -10,14 +21,32 @@ module Typesense
       @items = CurationSetItems.new(@curation_set_name, @api_call)
     end
 
+    # Create or update a curation set with the given name
+    #
+    # @example
+    #   client.curation_sets['my-set'].upsert('items' => [{ 'id' => 'promote-hat', 'rule' => { 'query' => 'hat', 'match' => 'exact' } }])
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def upsert(curation_set_data)
       @api_call.put(endpoint_path, curation_set_data)
     end
 
+    # Retrieve a specific curation set by its name
+    #
+    # @example
+    #   client.curation_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete a specific curation set by its name
+    #
+    # @example
+    #   client.curation_sets['my-set'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/curation_set_item.rb
+++ b/lib/typesense/curation_set_item.rb
@@ -8,14 +8,32 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve a specific curation item by its id
+    #
+    # @example
+    #   client.curation_sets['my-set'].items['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Create or update a curation set item with the given id
+    #
+    # @example
+    #   client.curation_sets['my-set'].items['promote-hat'].upsert('rule' => { 'query' => 'hat', 'match' => 'exact' }, 'includes' => [])
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def upsert(params)
       @api_call.put(endpoint_path, params)
     end
 
+    # Delete a specific curation item by its id
+    #
+    # @example
+    #   client.curation_sets['my-set'].items['promote-hat'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/curation_set_items.rb
+++ b/lib/typesense/curation_set_items.rb
@@ -8,10 +8,24 @@ module Typesense
       @items = {}
     end
 
+    # Retrieve all curation items in a set
+    #
+    # @example
+    #   client.curation_sets['my-set'].items.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual curation item by ID within this curation set.
+    #
+    # @example
+    #   client.curation_sets['my-set'].items['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [CurationSetItem]
     def [](item_id)
       @items[item_id] ||= CurationSetItem.new(@curation_set_name, item_id, @api_call)
     end

--- a/lib/typesense/curation_sets.rb
+++ b/lib/typesense/curation_sets.rb
@@ -8,14 +8,34 @@ module Typesense
       @api_call = api_call
     end
 
+    # Create or update a curation set with the given name
+    #
+    # @example
+    #   client.curation_sets.upsert('my-set', 'items' => [{ 'id' => 'promote-hat', 'rule' => { 'query' => 'hat', 'match' => 'exact' } }])
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def upsert(curation_set_name, curation_set_data)
       @api_call.put("#{self.class::RESOURCE_PATH}/#{URI.encode_www_form_component(curation_set_name)}", curation_set_data)
     end
 
+    # Retrieve all curation sets
+    #
+    # @example
+    #   client.curation_sets.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(self.class::RESOURCE_PATH)
     end
 
+    # Access an individual curation set by name.
+    #
+    # @example
+    #   client.curation_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [CurationSet]
     def [](curation_set_name)
       CurationSet.new(curation_set_name, @api_call)
     end

--- a/lib/typesense/debug.rb
+++ b/lib/typesense/debug.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve server version and state information.
+    #
+    # @example
+    #   client.debug.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html#debug
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end

--- a/lib/typesense/document.rb
+++ b/lib/typesense/document.rb
@@ -8,14 +8,32 @@ module Typesense
       @api_call        = api_call
     end
 
+    # Fetch an individual document from a collection by using its ID.
+    #
+    # @example
+    #   client.collections['products'].documents['1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#retrieve-a-document
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete an individual document from a collection by using its ID.
+    #
+    # @example
+    #   client.collections['products'].documents['1'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#delete-a-document
     def delete
       @api_call.delete(endpoint_path)
     end
 
+    # Update an individual document by ID by merging the provided fields.
+    #
+    # @example
+    #   client.collections['products'].documents['1'].update('in_stock' => true)
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#update-a-document
     def update(partial_document, options = {})
       @api_call.patch(endpoint_path, partial_document, options)
     end

--- a/lib/typesense/documents.rb
+++ b/lib/typesense/documents.rb
@@ -12,14 +12,34 @@ module Typesense
       @documents       = {}
     end
 
+    # Index a single document. The document must conform to the schema of the collection.
+    #
+    # @example
+    #   client.collections['products'].documents.create('id' => '1', 'title' => 'Hat')
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#index-a-single-document
     def create(document, options = {})
       @api_call.post(endpoint_path, document, options)
     end
 
+    # Upsert a single document. Creates the document if it does not exist, otherwise updates it.
+    #
+    # @example
+    #   client.collections['products'].documents.upsert('id' => '1', 'title' => 'Hat')
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#upsert
     def upsert(document, options = {})
       @api_call.post(endpoint_path, document, options.merge(action: :upsert))
     end
 
+    # Update documents matching a `filter_by` condition, or update a single document with `action: "update"` semantics.
+    #
+    # @example
+    #   client.collections['products'].documents.update({ 'in_stock' => true }, filter_by: 'category:=hats')
+    # @example
+    #   client.collections['products'].documents.update('id' => '1', 'title' => 'Hat')
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#update-documents-with-conditional-query
     def update(document, options = {})
       if options['filter_by'] || options[:filter_by]
         @api_call.patch(endpoint_path, document, options)
@@ -28,11 +48,21 @@ module Typesense
       end
     end
 
+    # @deprecated Use {#import} instead, which accepts both an array of documents or a JSONL string.
     def create_many(documents, options = {})
       @api_call.logger.warn('#create_many is deprecated and will be removed in a future version. Use #import instead, which now takes both an array of documents or a JSONL string of documents')
       import(documents, options)
     end
 
+    # Import documents into a collection. Accepts a JSONL string or an array of document hashes.
+    #
+    # @example
+    #   client.collections['products'].documents.import([{ 'id' => '1', 'title' => 'Hat' }, { 'id' => '2', 'title' => 'Shirt' }])
+    # @example
+    #   client.collections['products'].documents.import(jsonl_string)
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#index-multiple-documents
+    #
     # @param [Array,String] documents An array of document hashes or a JSONL string of documents.
     def import(documents, options = {})
       documents_in_jsonl_format = if documents.is_a?(Array)
@@ -65,22 +95,54 @@ module Typesense
       end
     end
 
+    # Export all documents in a collection as a JSONL string.
+    #
+    # @example
+    #   client.collections['products'].documents.export
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#export-documents
     def export(options = {})
       @api_call.get(endpoint_path('export'), options)
     end
 
+    # Search for documents in a collection that match the search criteria.
+    #
+    # @example
+    #   client.collections['products'].documents.search('q' => '*', 'query_by' => 'title')
+    #
+    # @see https://typesense.org/docs/latest/api/search.html
     def search(search_parameters)
       @api_call.get(endpoint_path('search'), search_parameters)
     end
 
+    # Access an individual document by ID within this collection.
+    #
+    # @example
+    #   client.collections['products'].documents['1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html
+    #
+    # @return [Document]
     def [](document_id)
       @documents[document_id] ||= Document.new(@collection_name, document_id, @api_call)
     end
 
+    # Delete a bunch of documents that match a specific filter condition.
+    #
+    # @example
+    #   client.collections['products'].documents.delete(filter_by: 'in_stock:=false')
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#delete-by-query
     def delete(query_parameters = {})
       @api_call.delete(endpoint_path, query_parameters)
     end
 
+    # Truncate all documents in the collection.
+    #
+    # @example
+    #   client.collections['products'].documents.truncate
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#delete-by-query
     def truncate
       @api_call.delete(endpoint_path, { truncate: true })
     end

--- a/lib/typesense/health.rb
+++ b/lib/typesense/health.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Checks if Typesense server is ready to accept requests.
+    #
+    # @example
+    #   client.health.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html#health
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end

--- a/lib/typesense/key.rb
+++ b/lib/typesense/key.rb
@@ -7,10 +7,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve (metadata about) a key. Only the key prefix is returned when you retrieve a key. Due to security reasons, only the create endpoint returns the full API key.
+    #
+    # @example
+    #   client.keys[1].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html#retrieve-an-api-key
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete an API key given its ID.
+    #
+    # @example
+    #   client.keys[1].delete
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html#delete-api-key
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/keys.rb
+++ b/lib/typesense/keys.rb
@@ -13,14 +13,32 @@ module Typesense
       @keys = {}
     end
 
+    # Create an API Key with fine-grain access control. You can restrict access on both a per-collection and per-action level. The generated key is returned only during creation. You want to store this key carefully in a secure place.
+    #
+    # @example
+    #   client.keys.create('description' => 'Search-only key', 'actions' => ['documents:search'], 'collections' => ['*'])
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html#create-an-api-key
     def create(parameters)
       @api_call.post(RESOURCE_PATH, parameters)
     end
 
+    # Retrieve (metadata about) all keys.
+    #
+    # @example
+    #   client.keys.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html#list-all-keys
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end
 
+    # Generate a scoped search-only API key with embedded parameters such as `filter_by` or `expires_at`.
+    #
+    # @example
+    #   client.keys.generate_scoped_search_key('search-only-key', 'filter_by' => 'company_id:124', 'expires_at' => 1700000000)
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html#generate-scoped-search-key
     def generate_scoped_search_key(search_key, parameters)
       parameters_json = JSON.dump(parameters)
       digest = Base64.encode64(OpenSSL::HMAC.digest('sha256', search_key, parameters_json)).gsub("\n", '')
@@ -29,6 +47,14 @@ module Typesense
       Base64.encode64(raw_scoped_key).gsub("\n", '')
     end
 
+    # Access an individual API key by ID.
+    #
+    # @example
+    #   client.keys[1].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/api-keys.html
+    #
+    # @return [Key]
     def [](id)
       @keys[id] ||= Key.new(id, @api_call)
     end

--- a/lib/typesense/metrics.rb
+++ b/lib/typesense/metrics.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Get current RAM, CPU, Disk & Network usage metrics.
+    #
+    # @example
+    #   client.metrics.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end

--- a/lib/typesense/multi_search.rb
+++ b/lib/typesense/multi_search.rb
@@ -8,6 +8,14 @@ module Typesense
       @api_call = api_call
     end
 
+    # Send multiple search requests in a single HTTP request. Pass `union: true` to merge results, or omit it to receive a `results` array.
+    #
+    # @example
+    #   client.multi_search.perform('searches' => [{ 'collection' => 'products', 'q' => '*' }])
+    # @example
+    #   client.multi_search.perform('union' => true, 'searches' => [{ 'collection' => 'products', 'q' => '*' }])
+    #
+    # @see https://typesense.org/docs/latest/api/documents.html#federated-multi-search
     def perform(searches, query_params = {})
       @api_call.post(RESOURCE_PATH, searches, query_params)
     end

--- a/lib/typesense/nl_search_model.rb
+++ b/lib/typesense/nl_search_model.rb
@@ -7,14 +7,32 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve a specific NL search model by its ID.
+    #
+    # @example
+    #   client.nl_search_models['model-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Update an existing NL search model.
+    #
+    # @example
+    #   client.nl_search_models['model-1'].update('model_name' => 'openai/gpt-4')
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
     def update(update_schema)
       @api_call.put(endpoint_path, update_schema)
     end
 
+    # Delete a specific NL search model by its ID.
+    #
+    # @example
+    #   client.nl_search_models['model-1'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/nl_search_models.rb
+++ b/lib/typesense/nl_search_models.rb
@@ -9,14 +9,34 @@ module Typesense
       @nl_search_models = {}
     end
 
+    # Create a new NL search model.
+    #
+    # @example
+    #   client.nl_search_models.create('model_name' => 'openai/gpt-4', 'api_key' => '...')
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
     def create(schema)
       @api_call.post(RESOURCE_PATH, schema)
     end
 
+    # Retrieve all NL search models.
+    #
+    # @example
+    #   client.nl_search_models.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end
 
+    # Access an individual NL search model by ID.
+    #
+    # @example
+    #   client.nl_search_models['model-1'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/natural-language-search.html
+    #
+    # @return [NlSearchModel]
     def [](model_id)
       @nl_search_models[model_id] ||= NlSearchModel.new(model_id, @api_call)
     end

--- a/lib/typesense/operations.rb
+++ b/lib/typesense/operations.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Perform a cluster operation: snapshot, vote, cache/clear, db/compact, or a custom path.
+    #
+    # @example
+    #   client.operations.perform('snapshot', 'snapshot_path' => '/tmp/snap')
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
     def perform(operation_name, query_params = {})
       @api_call.post("#{RESOURCE_PATH}/#{operation_name}", {}, query_params)
     end

--- a/lib/typesense/override.rb
+++ b/lib/typesense/override.rb
@@ -8,10 +8,22 @@ module Typesense
       @api_call        = api_call
     end
 
+    # Retrieve an override (curation rule) by ID on this collection.
+    #
+    # @example
+    #   client.collections['products'].overrides['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete an override (curation rule) by ID on this collection.
+    #
+    # @example
+    #   client.collections['products'].overrides['promote-hat'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/overrides.rb
+++ b/lib/typesense/overrides.rb
@@ -10,14 +10,34 @@ module Typesense
       @overrides       = {}
     end
 
+    # Create or update an override (curation rule) on this collection.
+    #
+    # @example
+    #   client.collections['products'].overrides.upsert('promote-hat', 'rule' => { 'query' => 'hat', 'match' => 'exact' }, 'includes' => [])
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def upsert(override_id, params)
       @api_call.put(endpoint_path(override_id), params)
     end
 
+    # Retrieve all overrides (curation rules) on this collection.
+    #
+    # @example
+    #   client.collections['products'].overrides.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual override by ID within this collection.
+    #
+    # @example
+    #   client.collections['products'].overrides['promote-hat'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/curation.html
+    #
+    # @return [Override]
     def [](override_id)
       @overrides[override_id] ||= Override.new(@collection_name, override_id, @api_call)
     end

--- a/lib/typesense/preset.rb
+++ b/lib/typesense/preset.rb
@@ -7,10 +7,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve the details of a preset, given it's name.
+    #
+    # @example
+    #   client.presets['listing_view'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Permanently deletes a preset, given it's name.
+    #
+    # @example
+    #   client.presets['listing_view'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/presets.rb
+++ b/lib/typesense/presets.rb
@@ -9,14 +9,34 @@ module Typesense
       @presets = {}
     end
 
+    # Create or update an existing preset.
+    #
+    # @example
+    #   client.presets.upsert('listing_view', 'value' => { 'q' => '*' })
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
     def upsert(preset_name, params)
       @api_call.put(endpoint_path(preset_name), params)
     end
 
+    # Retrieve the details of all presets
+    #
+    # @example
+    #   client.presets.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual preset by ID.
+    #
+    # @example
+    #   client.presets['listing_view'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/search.html#presets
+    #
+    # @return [Preset]
     def [](preset_name)
       @presets[preset_name] ||= Preset.new(preset_name, @api_call)
     end

--- a/lib/typesense/stats.rb
+++ b/lib/typesense/stats.rb
@@ -8,6 +8,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Get stats about API endpoints.
+    #
+    # @example
+    #   client.stats.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/cluster-operations.html
     def retrieve
       @api_call.get(RESOURCE_PATH)
     end

--- a/lib/typesense/stemming.rb
+++ b/lib/typesense/stemming.rb
@@ -8,6 +8,17 @@ module Typesense
       @api_call = api_call
     end
 
+    # Access the stemming dictionaries resource. Use it to list or import dictionaries, or as an array
+    # to access a single dictionary by ID.
+    #
+    # @example
+    #   client.stemming.dictionaries.retrieve
+    # @example
+    #   client.stemming.dictionaries['en'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
+    #
+    # @return [StemmingDictionaries]
     def dictionaries
       @dictionaries ||= StemmingDictionaries.new(@api_call)
     end

--- a/lib/typesense/stemming_dictionaries.rb
+++ b/lib/typesense/stemming_dictionaries.rb
@@ -9,6 +9,12 @@ module Typesense
       @dictionaries = {}
     end
 
+    # Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+    #
+    # @example
+    #   client.stemming.dictionaries.upsert('irregular-plurals', [{ 'word' => 'people', 'root' => 'person' }])
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
     def upsert(dict_id, words_and_roots_combinations)
       words_and_roots_combinations_in_jsonl = if words_and_roots_combinations.is_a?(Array)
                                                 words_and_roots_combinations.map { |combo| JSON.dump(combo) }.join("\n")
@@ -31,11 +37,25 @@ module Typesense
       end
     end
 
+    # Retrieve a list of all available stemming dictionaries.
+    #
+    # @example
+    #   client.stemming.dictionaries.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
     def retrieve
       response = @api_call.get(endpoint_path)
       response || { 'dictionaries' => [] }
     end
 
+    # Access an individual stemming dictionary by ID.
+    #
+    # @example
+    #   client.stemming.dictionaries['en'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
+    #
+    # @return [StemmingDictionary]
     def [](dict_id)
       @dictionaries[dict_id] ||= StemmingDictionary.new(dict_id, @api_call)
     end

--- a/lib/typesense/stemming_dictionary.rb
+++ b/lib/typesense/stemming_dictionary.rb
@@ -7,6 +7,12 @@ module Typesense
       @api_call = api_call
     end
 
+    # Fetch details of a specific stemming dictionary.
+    #
+    # @example
+    #   client.stemming.dictionaries['en'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/stemming.html
     def retrieve
       @api_call.get(endpoint_path)
     end

--- a/lib/typesense/synonym.rb
+++ b/lib/typesense/synonym.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Typesense
+  # @deprecated Deprecated starting with Typesense Server v30. Please migrate to `client.synonym_sets` (new Synonym Sets APIs).
   class Synonym
     def initialize(collection_name, synonym_id, api_call)
       @collection_name = collection_name
@@ -8,10 +9,22 @@ module Typesense
       @api_call = api_call
     end
 
+    # Retrieve a synonym (legacy v1) by ID on this collection.
+    #
+    # @example
+    #   client.collections['products'].synonyms['syn-1'].retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/synonyms.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete a synonym (legacy v1) by ID on this collection.
+    #
+    # @example
+    #   client.collections['products'].synonyms['syn-1'].delete
+    #
+    # @see https://typesense.org/docs/29.0/api/synonyms.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/synonym_set.rb
+++ b/lib/typesense/synonym_set.rb
@@ -7,14 +7,32 @@ module Typesense
       @api_call = api_call
     end
 
+    # Create or update a synonym set with the given name
+    #
+    # @example
+    #   client.synonym_sets['my-set'].upsert('items' => [{ 'id' => 'syn-1', 'synonyms' => ['nyc', 'new york'] }])
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
     def upsert(params)
       @api_call.put(endpoint_path, params)
     end
 
+    # Retrieve a specific synonym set by its name
+    #
+    # @example
+    #   client.synonym_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Delete a specific synonym set by its name
+    #
+    # @example
+    #   client.synonym_sets['my-set'].delete
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
     def delete
       @api_call.delete(endpoint_path)
     end

--- a/lib/typesense/synonym_sets.rb
+++ b/lib/typesense/synonym_sets.rb
@@ -9,14 +9,34 @@ module Typesense
       @synonym_sets = {}
     end
 
+    # Create or update a synonym set with the given name
+    #
+    # @example
+    #   client.synonym_sets.upsert('my-set', 'items' => [{ 'id' => 'syn-1', 'synonyms' => ['nyc', 'new york'] }])
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
     def upsert(synonym_set_name, params)
       @api_call.put(endpoint_path(synonym_set_name), params)
     end
 
+    # Retrieve all synonym sets
+    #
+    # @example
+    #   client.synonym_sets.retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual synonym set by name.
+    #
+    # @example
+    #   client.synonym_sets['my-set'].retrieve
+    #
+    # @see https://typesense.org/docs/latest/api/synonyms.html
+    #
+    # @return [SynonymSet]
     def [](synonym_set_name)
       @synonym_sets[synonym_set_name] ||= SynonymSet.new(synonym_set_name, @api_call)
     end

--- a/lib/typesense/synonyms.rb
+++ b/lib/typesense/synonyms.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Typesense
+  # @deprecated Deprecated starting with Typesense Server v30. Please migrate to `client.synonym_sets` (new Synonym Sets APIs).
   class Synonyms
     RESOURCE_PATH = '/synonyms'
 
@@ -10,14 +11,34 @@ module Typesense
       @synonyms = {}
     end
 
+    # Create or update a synonym (legacy v1) on this collection.
+    #
+    # @example
+    #   client.collections['products'].synonyms.upsert('syn-1', 'synonyms' => ['nyc', 'new york'])
+    #
+    # @see https://typesense.org/docs/29.0/api/synonyms.html
     def upsert(synonym_id, params)
       @api_call.put(endpoint_path(synonym_id), params)
     end
 
+    # Retrieve all synonyms (legacy v1) on this collection.
+    #
+    # @example
+    #   client.collections['products'].synonyms.retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/synonyms.html
     def retrieve
       @api_call.get(endpoint_path)
     end
 
+    # Access an individual synonym by ID within this collection.
+    #
+    # @example
+    #   client.collections['products'].synonyms['syn-1'].retrieve
+    #
+    # @see https://typesense.org/docs/29.0/api/synonyms.html
+    #
+    # @return [Synonym]
     def [](synonym_id)
       @synonyms[synonym_id] ||= Synonym.new(@collection_name, synonym_id, @api_call)
     end


### PR DESCRIPTION
## Change Summary
- annotate each public resource method with description, `@example`, and `@see` link sourced from the JS and PHP clients
- split `Client`'s grouped `attr_reader` into per-resource accessors with YARD blocks so each shows up under hover
- adapt examples to ruby idioms — `client.collections['products']` bracket access, string-key hashes, no trailing parens
- keep `/29.0/` versioned docs links on legacy `AnalyticsV1` and collection-scoped `Synonyms`, `/latest/` everywhere else
- mark `AnalyticsV1`, `Synonyms`, and `Synonym` with `@deprecated` pointing to the v30 replacements


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
